### PR TITLE
Manage context_path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -144,7 +144,11 @@ Specify a gid of the confluence user. Default: undef
 #####`shell`
 Specify the shell of the confluence user. Default: undef
 #####`manage_user`
-Weather or not to manage the confluence user. Default: true
+Whether or not to manage the confluence user. Default: true
+#####`context_path`
+Specify context path, defaults to ''. If modified, Once Confluence has started,
+go to the administration area and click General Configuration.
+Append the new context path to your base URL.
 
 ####JVM Java parameters####
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class confluence (
   $tomcat_proxy = {},
   # Any additional tomcat params for server.xml
   $tomcat_extras = {},
+  $context_path  = '',
 
   # Command to stop confluence in preparation to updgrade. This is configurable
   # incase the confluence service is managed outside of puppet. eg: using the

--- a/spec/acceptance/3_custom_parameters_spec.rb
+++ b/spec/acceptance/3_custom_parameters_spec.rb
@@ -35,12 +35,13 @@ describe 'confluence', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
         tomcat_port         => '8091',
         tomcat_max_threads  => 999,
         tomcat_accept_count => 999,
+        context_path        => '/confluence1',
       }
     EOS
     apply_manifest(pp, :catch_failures => true)
-    shell 'wget -q --tries=240 --retry-connrefused --read-timeout=10 localhost:8091', :acceptable_exit_codes => [0]
+    shell 'wget -q --tries=240 --retry-connrefused --read-timeout=10 localhost:8091/confluence1', :acceptable_exit_codes => [0]
     sleep 60
-    shell 'wget -q --tries=240 --retry-connrefused --read-timeout=10 localhost:8091', :acceptable_exit_codes => [0]
+    shell 'wget -q --tries=240 --retry-connrefused --read-timeout=10 localhost:8091/confluence1', :acceptable_exit_codes => [0]
     sleep 30
     apply_manifest(pp, :catch_changes => true)
   end
@@ -69,13 +70,14 @@ describe 'confluence', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
     it { should have_login_shell '/bin/true' }
   end
 
-  describe command('wget -q --tries=240 --retry-connrefused --read-timeout=10 -O- localhost:8091') do
+  describe command('wget -q --tries=240 --retry-connrefused --read-timeout=10 -O- localhost:8091/confluence1') do
     its(:stdout) { should match (/http\:\/\/www\.atlassian\.com\//) }
   end
 
   describe file('/opt/confluence/atlassian-confluence-5.7/conf/server.xml') do
     it { should contain "maxThreads=\"999\"" }
     it { should contain "acceptCount=\"999\"" }
+    it { should contain "Context path=\"/confluence\"" }
   end
 
 end

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -15,7 +15,7 @@ describe 'confluence' do
       let(:params) {{
         :javahome          => '/opt/java',
         :version           => '5.5.6',
-	      :manage_server_xml => 'template',
+        :manage_server_xml => 'template',
       }}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh')}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties')}
@@ -25,7 +25,7 @@ describe 'confluence' do
       let(:params) {{
         :javahome          => '/opt/java',
         :version           => '5.5.6',
-	      :manage_server_xml => 'ERROR',
+        :manage_server_xml => 'ERROR',
       }}
       it('should fail') {
         should raise_error(Puppet::Error, /manage_server_xml must be "augeas" or "template"/)
@@ -35,7 +35,7 @@ describe 'confluence' do
       let(:params) {{
         :javahome            => '/opt/java',
         :version             => '5.5.6',
-	      :manage_server_xml   => 'template',
+        :manage_server_xml   => 'template',
         :context_path        => '/confluence1',
         :tomcat_port         => 8089,
         :tomcat_max_threads  => 999,
@@ -43,8 +43,8 @@ describe 'confluence' do
         :tomcat_proxy        => {
           'scheme'      => 'https',
           'proxyName'   => 'EXAMPLE',
-	        'proxyPort'   => '443',
-	      },
+          'proxyPort'   => '443',
+        },
       }}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh')}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties')}

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -15,7 +15,7 @@ describe 'confluence' do
       let(:params) {{
         :javahome          => '/opt/java',
         :version           => '5.5.6',
-	:manage_server_xml => 'template',
+	      :manage_server_xml => 'template',
       }}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh')}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties')}
@@ -25,7 +25,7 @@ describe 'confluence' do
       let(:params) {{
         :javahome          => '/opt/java',
         :version           => '5.5.6',
-	:manage_server_xml => 'ERROR',
+	      :manage_server_xml => 'ERROR',
       }}
       it('should fail') {
         should raise_error(Puppet::Error, /manage_server_xml must be "augeas" or "template"/)
@@ -35,15 +35,16 @@ describe 'confluence' do
       let(:params) {{
         :javahome            => '/opt/java',
         :version             => '5.5.6',
-	:manage_server_xml   => 'template',
+	      :manage_server_xml   => 'template',
+        :context_path        => '/confluence1',
         :tomcat_port         => 8089,
         :tomcat_max_threads  => 999,
         :tomcat_accept_count => 999,
         :tomcat_proxy        => {
           'scheme'      => 'https',
           'proxyName'   => 'EXAMPLE',
-	  'proxyPort'   => '443',
-	},
+	        'proxyPort'   => '443',
+	      },
       }}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh')}
       it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties')}
@@ -54,6 +55,7 @@ describe 'confluence' do
         .with_content(/scheme="https"/)
         .with_content(/proxyName="EXAMPLE"/)
         .with_content(/proxyPort="443"/)
+        .with_content(/Context path="\/confluence1"/)
       }
     end
   end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -23,7 +23,7 @@
 
             <Host name="localhost" debug="0" appBase="webapps" unpackWARs="true" autoDeploy="false">
 
-                <Context path="" docBase="../confluence" debug="0" reloadable="false" useHttpOnly="true">
+                <Context path="<%= @context_path %>" docBase="../confluence" debug="0" reloadable="false" useHttpOnly="true">
                     <!-- Logger is deprecated in Tomcat 5.5. Logging configuration for Confluence is specified in confluence/WEB-INF/classes/log4j.properties -->
                     <Manager pathname="" />
                 </Context>


### PR DESCRIPTION
This commit adds a parameter called "context_path" to the base class and
config class to manage Tomcat's context path.  This is useful for
situations where Confluence is served from a sub-path to the base url.

Managing this with both Augeas and with the server.xml template is
supported.  It defaults to '' (empty string), providing backwards-compatibility and
reasonable defaults.

Should resolve #36 and #21 